### PR TITLE
Add struct that disables interrupts while in scope

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(core_panic_info)]
 #![feature(integer_atomics)]
 #![feature(lang_items)]
+#![feature(optin_builtin_traits)]
 #![cfg_attr(not(test), no_std)]
 
 #[cfg(not(test))]

--- a/kernel/src/x86_util.rs
+++ b/kernel/src/x86_util.rs
@@ -1,3 +1,5 @@
+use x86_64::registers::rflags;
+
 pub unsafe fn outb(port: u16, value: u8) {
     asm!("outb %al, %dx" :: "{al}"(value), "{dx}"(port));
 }
@@ -6,4 +8,33 @@ pub unsafe fn inb(port: u16) -> u8 {
     let value: u8;
     asm!("inb %dx, %al" : "={al}"(value) : "{dx}"(port));
     value
+}
+
+/// Disables interrupts while in scope. When dropped, this resets
+/// rflags to their original state.
+pub struct ScopedInterruptDisabler {
+    saved_flags: u64,
+}
+
+impl !Send for ScopedInterruptDisabler {}
+impl !Sync for ScopedInterruptDisabler {}
+
+impl ScopedInterruptDisabler {
+    pub fn new() -> ScopedInterruptDisabler {
+        let saved_flags = rflags::read_raw();
+
+        unsafe {
+            asm!("cli");
+        }
+
+        ScopedInterruptDisabler {
+            saved_flags: saved_flags,
+        }
+    }
+}
+
+impl Drop for ScopedInterruptDisabler {
+    fn drop(&mut self) {
+        rflags::write_raw(self.saved_flags);
+    }
 }


### PR DESCRIPTION
This frees us from having to worry about re-enabling interrupts correctly. Also, it doesn't enable interrupts if they weren't already enabled.